### PR TITLE
Enable Windows Firewall and Defender during workstation setup

### DIFF
--- a/Applications/Default/Configure Workstation.ps1
+++ b/Applications/Default/Configure Workstation.ps1
@@ -380,11 +380,20 @@ if (Get-UACLevel -eq "Never notify") {
     Write-Host "Failed" -ForegroundColor Red
 }
 
-#Disable Windows Firewall
-Write-Host "Disabling Windows Firewall..." -NoNewline
-$setFirewallRegistryResult = Set-RegistryValue -key "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Notifications\Settings\Windows.SystemToast.SecurityAndMaintenance" -name "Enabled" -type DWORD -value 0
-Set-NetFirewallProfile -All -Enabled False | Out-Null
-if ((Get-NetFirewallProfile -Name Public).Enabled -eq $false -and (Get-NetFirewallProfile -Name Private).Enabled -eq $false -and (Get-NetFirewallProfile -Name Domain).Enabled -eq $false) {
+#Enable Windows Firewall and Windows Defender
+Write-Host "Enabling Windows Firewall..." -NoNewline
+$setFirewallRegistryResult = Set-RegistryValue -key "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Notifications\Settings\Windows.SystemToast.SecurityAndMaintenance" -name "Enabled" -type DWORD -value 1
+Set-NetFirewallProfile -All -Enabled True | Out-Null
+if ((Get-NetFirewallProfile -Name Public).Enabled -eq $true -and (Get-NetFirewallProfile -Name Private).Enabled -eq $true -and (Get-NetFirewallProfile -Name Domain).Enabled -eq $true) {
+    Write-Host "OK" -ForegroundColor Green
+} else {
+    Write-Host "Failed" -ForegroundColor Red
+}
+
+Write-Host "Enabling Windows Defender..." -NoNewline
+Set-MpPreference -DisableRealtimeMonitoring $false
+Start-MpService | Out-Null
+if ((Get-MpComputerStatus).RealTimeProtectionEnabled -eq $true) {
     Write-Host "OK" -ForegroundColor Green
 } else {
     Write-Host "Failed" -ForegroundColor Red

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Basically, one file runs another, which runs another...which runs another... unt
 ### ***Step1.bat***
 1. References **variables.bat** to determine which sections execute using if statements.  
 2. Disables IE Enhanced Security mode (Errors on workstations)
-3. Runs **Configure Workstation.ps1** which re-names the computer, disables built-in firewall, and removes built-in bloatware.
+3. Runs **Configure Workstation.ps1** which re-names the computer, enables the built-in firewall and Windows Defender, and removes built-in bloatware.
 4. Sets NTP server to **time.windows.com** and **time.google.com** and configures computer to sync. 
 5. Enables RDP for the workstation
 6. Installs Adobe Reader by downloading and executing the install file. 


### PR DESCRIPTION
## Summary
- ensure Configure Workstation.ps1 enables Windows Firewall and Windows Defender rather than disabling
- document firewall/Defender enabling in README

## Testing
- `pwsh -NoProfile -Command "[System.Management.Automation.Language.Parser]::ParseFile('Applications/Default/Configure Workstation.ps1',[ref]$null,[ref]$null) | Out-Null; Write-Host 'Syntax OK'"` *(command not found)*
- `apt-get update >/tmp/apt.log && tail -n 20 /tmp/apt.log` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_b_689be4bf28648327a6c8305c2188128b