### PR TITLE
Enable Windows Firewall and Defender during workstation setup

### DIFF
--- a/Applications/Default/Configure Workstation.ps1
+++ b/Applications/Default/Configure Workstation.ps1
@@ -380,11 +380,21 @@ if (Get-UACLevel -eq "Never notify") {
     Write-Host "Failed" -ForegroundColor Red
 }
 
-#Disable Windows Firewall
-Write-Host "Disabling Windows Firewall..." -NoNewline
-$setFirewallRegistryResult = Set-RegistryValue -key "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Notifications\Settings\Windows.SystemToast.SecurityAndMaintenance" -name "Enabled" -type DWORD -value 0
-Set-NetFirewallProfile -All -Enabled False | Out-Null
-if ((Get-NetFirewallProfile -Name Public).Enabled -eq $false -and (Get-NetFirewallProfile -Name Private).Enabled -eq $false -and (Get-NetFirewallProfile -Name Domain).Enabled -eq $false) {
+#Enable Windows Firewall and Windows Defender
+Write-Host "Enabling Windows Firewall..." -NoNewline
+$setFirewallRegistryResult = Set-RegistryValue -key "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Notifications\Settings\Windows.SystemToast.SecurityAndMaintenance" -name "Enabled" -type DWORD -value 1
+Set-NetFirewallProfile -All -Enabled True | Out-Null
+if ((Get-NetFirewallProfile -Name Public).Enabled -eq $true -and (Get-NetFirewallProfile -Name Private).Enabled -eq $true -and (Get-NetFirewallProfile -Name Domain).Enabled -eq $true) {
+    Write-Host "OK" -ForegroundColor Green
+} else {
+    Write-Host "Failed" -ForegroundColor Red
+}
+
+Write-Host "Enabling Windows Defender..." -NoNewline
+Set-MpPreference -DisableRealtimeMonitoring $false | Out-Null
+Start-Service -Name WinDefend -ErrorAction SilentlyContinue | Out-Null
+$defenderStatus = Get-MpComputerStatus -ErrorAction SilentlyContinue
+if ($defenderStatus.RealTimeProtectionEnabled -eq $true -and (Get-Service -Name WinDefend -ErrorAction SilentlyContinue).Status -eq 'Running') {
     Write-Host "OK" -ForegroundColor Green
 } else {
     Write-Host "Failed" -ForegroundColor Red

--- a/Applications/Menu.ps1
+++ b/Applications/Menu.ps1
@@ -6,7 +6,10 @@ function GenerateForm {
     $form1 = New-Object System.Windows.Forms.Form
     $button1 = New-Object System.Windows.Forms.Button
     $listBox1 = New-Object System.Windows.Forms.ListBox
-    
+
+    # Remove McAfee Antivirus (var3.11)
+    $checkBox23 = New-Object System.Windows.Forms.CheckBox
+
     # Teamviewer 9 (var3.10)
     $checkBox22 = New-Object System.Windows.Forms.CheckBox
     
@@ -263,6 +266,14 @@ function GenerateForm {
     
     
     
+        if ($checkBox23.Checked)    {  $listBox1.Items.Add( "Removing McAfee Antivirus"  )
+        "set var3.11=yes" | Out-File -append -Encoding ascii -FilePath "C:\Users\$env:UserName\Desktop\Applications\variables.bat"
+         }
+
+        else   {  $listBox1.Items.Add( "No McAfee Removal"  )
+        "set var3.11=no" | Out-File -append -Encoding ascii -FilePath "C:\Users\$env:UserName\Desktop\Applications\variables.bat"
+         }
+
         if ( !$checkBox1.Checked -and !$checkBox2.Checked -and !$checkBox3.Checked ) {   $listBox1.Items.Add("No CheckBox selected....")} 
     
     start-process -FilePath C:\Users\$env:UserName\Desktop\Applications\Stepstart.bat
@@ -296,7 +307,7 @@ function GenerateForm {
     
     $System_Drawing_Point = New-Object System.Drawing.Point
     $System_Drawing_Point.X = 27
-    $System_Drawing_Point.Y = 695
+    $System_Drawing_Point.Y = 726
     $button1.Location = $System_Drawing_Point
     $button1.DataBindings.DefaultDataSourceUpdateMode = 0
     $button1.add_Click($handler_button1_Click)
@@ -331,8 +342,24 @@ function GenerateForm {
     $checkBox22.Location = $System_Drawing_Point
     $checkBox22.DataBindings.DefaultDataSourceUpdateMode = 0
     $checkBox22.Name = "checkBox22"
-    
+
     $form1.Controls.Add($checkBox22)
+
+    $checkBox23.UseVisualStyleBackColor = $True
+    $System_Drawing_Size = New-Object System.Drawing.Size
+    $System_Drawing_Size.Width = 104
+    $System_Drawing_Size.Height = 34
+    $checkBox23.Size = $System_Drawing_Size
+    $checkBox23.TabIndex = 2
+    $checkBox23.Text = "Remove McAfee"
+    $System_Drawing_Point = New-Object System.Drawing.Point
+    $System_Drawing_Point.X = 27
+    $System_Drawing_Point.Y = 695
+    $checkBox23.Location = $System_Drawing_Point
+    $checkBox23.DataBindings.DefaultDataSourceUpdateMode = 0
+    $checkBox23.Name = "checkBox23"
+
+    $form1.Controls.Add($checkBox23)
     
     $checkBox21.UseVisualStyleBackColor = $True
     $System_Drawing_Size = New-Object System.Drawing.Size

--- a/Applications/Step.3.bat
+++ b/Applications/Step.3.bat
@@ -3,8 +3,8 @@
 set cpath="C:\Users\%username%\Desktop\Applications"
 call %cpath%\variables.bat
 
-if %var3.1%==no if %var3.2%==no if %var3.3%==no if %var3.4%==no if %var3.5%==no if %var3.6%==no if %var3.7%==no if %var3.8%==no if %var3.9%==no if %var3.10%==no Powershell.exe -Command "Start-Process C:\Users\%username%\Desktop\Applications\Step.4.bat -Verb RunAs 
-if %var3.1%==no if %var3.2%==no if %var3.3%==no if %var3.4%==no if %var3.5%==no if %var3.6%==no if %var3.7%==no if %var3.8%==no if %var3.9%==no if %var3.10%==no STOP
+if %var3.1%==no if %var3.2%==no if %var3.3%==no if %var3.4%==no if %var3.5%==no if %var3.6%==no if %var3.7%==no if %var3.8%==no if %var3.9%==no if %var3.10%==no if %var3.11%==no Powershell.exe -Command "Start-Process C:\Users\%username%\Desktop\Applications\Step.4.bat -Verb RunAs
+if %var3.1%==no if %var3.2%==no if %var3.3%==no if %var3.4%==no if %var3.5%==no if %var3.6%==no if %var3.7%==no if %var3.8%==no if %var3.9%==no if %var3.10%==no if %var3.11%==no STOP
 
 REM Install Teams
 if %var3.1%==yes echo .
@@ -75,11 +75,17 @@ if %var3.9%==yes TIMEOUT 120
 REM Install Teamviewer 9
 if %var3.10%==yes echo .
 if %var3.10%==yes echo "Installing Teamviewer 9"
-if %var3.10%==yes Powershell.exe -Command "Start-Process -FilePath C:\Users\%username%\Desktop\Applications\Ulrich\TeamViewer\*.exe /S -Verb RunAs"
-if %var3.10%==yes TIMEOUT 120
+    if %var3.10%==yes Powershell.exe -Command "Start-Process -FilePath C:\Users\%username%\Desktop\Applications\Ulrich\TeamViewer\*.exe /S -Verb RunAs"
+    if %var3.10%==yes TIMEOUT 120
 
-REM Move next startup scripts and Cleanup previous
-echo "Cleaning up previous scripts."
+    REM Remove McAfee Antivirus
+    if %var3.11%==yes echo .
+    if %var3.11%==yes echo "Removing McAfee Antivirus"
+    if %var3.11%==yes wmic product where "name like 'McAfee%%'" call uninstall /nointeractive
+    if %var3.11%==yes TIMEOUT 120
+
+    REM Move next startup scripts and Cleanup previous
+    echo "Cleaning up previous scripts."
 del "C:\Users\%username%\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Startup\Admin.1.bat"
 del "C:\Users\%username%\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Startup\Admin.2.bat"
 del "C:\Users\%username%\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Startup\Admin.3.bat"

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Basically, one file runs another, which runs another...which runs another... unt
 ### ***Step1.bat***
 1. References **variables.bat** to determine which sections execute using if statements.  
 2. Disables IE Enhanced Security mode (Errors on workstations)
-3. Runs **Configure Workstation.ps1** which re-names the computer, disables built-in firewall, and removes built-in bloatware.
+3. Runs **Configure Workstation.ps1** which re-names the computer, enables the built-in firewall and Windows Defender, and removes built-in bloatware.
 4. Sets NTP server to **time.windows.com** and **time.google.com** and configures computer to sync. 
 5. Enables RDP for the workstation
 6. Installs Adobe Reader by downloading and executing the install file. 
@@ -125,9 +125,10 @@ Basically, one file runs another, which runs another...which runs another... unt
 4. Installs Office 365 by running the setup file located in **Applications\O365** and referencing the O365-specific configuration file (Also located in **Applications\O365**). 
 5. Installs BGInfo by calling the **BGInfo_Automated_Windows_Server_2023_R2.ps1** script. 
 6. Begins the Office 2019 setup process by running **OFFICE_SETUP.BAT** (*Currently Broken* and calls for user input, if selected)
-7. Installs various other deprecated programs, if selected.  These will be removed in future versions and replaced with newer software. 
-8. Deletes any previous script files from the startup folder and copies **Admin4.bat** to startup folder. 
-9. Reboots the PC (Regardless if any section was executed)
+7. Installs various other deprecated programs, if selected.  These will be removed in future versions and replaced with newer software.
+8. Removes pre-installed McAfee antivirus from Lenovo systems, if selected.
+9. Deletes any previous script files from the startup folder and copies **Admin4.bat** to startup folder.
+10. Reboots the PC (Regardless if any section was executed)
 
 ### ***Admin4.bat***
 1. Runs **Step4.bat** as Administrator to continue th eprocess after a reboot


### PR DESCRIPTION
## Summary
- ensure Configure Workstation.ps1 enables Windows Firewall and Windows Defender rather than disabling
- use Start-Service to start Defender service when enabling real-time protection
- document firewall/Defender enabling in README
- add GUI option to remove pre-installed McAfee antivirus and execute removal during Step 3

## Testing
- `pwsh -NoProfile -Command "[System.Management.Automation.Language.Parser]::ParseFile('Applications/Menu.ps1',[ref]$null,[ref]$null) | Out-Null; Write-Host 'Syntax OK'"` *(command not found)*
- `powershell -NoProfile -Command "[System.Management.Automation.Language.Parser]::ParseFile('Applications/Menu.ps1',[ref]$null,[ref]$null) | Out-Null; Write-Host 'Syntax OK'"` *(command not found)*
- `apt-get update >/tmp/apt.log && tail -n 20 /tmp/apt.log` *(repository not signed)*

------
https://chatgpt.com/codex/tasks/task_b_689be4bf28648327a6c8305c2188128b